### PR TITLE
update vagrant configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 ip_mapping.json
 hosts.base
 playbooks
+shared
+.vagrant

--- a/README.md
+++ b/README.md
@@ -11,10 +11,23 @@ in YAML format.
 
 Usage
 -------------
-Symlink playbooks like "ln -s /path/to/playbooks playbooks". Additionally, if you are using
-Ansible v2.4 then also make symlinks "ln -s playbooks/group_vars group_vars" and
-"ln -s playbooks/host_vars host_vars". Vagrant is ready to run, see a list of configured boxes
-with "vagrant status". IPs will be assigned on first run (in ip_mapping.json).
 
-Optionally generate a hosts file with "./inventory.rb --hosts". If using this, keep hosts.base up
+1. Install jinja2 version 2.8, newer versions have still bugs in ansible.
+    ```sh
+    pip install jinja2=2.8 --user
+    ```
+1. Install ansible version 2.7
+    ```sh
+    pip install ansible==2.7 --user
+    ```
+1. Symlink playbooks 
+    ```sh
+    ln -s /path/to/playbooks playbooks
+    ```
+1. Configure ansible-vault password path (vault_password_file) in ansible.cfg.
+
+Vagrant is ready to run, see a list of configured boxes
+with `vagrant status`. IPs will be assigned on first run (in ip_mapping.json).
+
+Optionally generate a hosts file with `./inventory.rb --hosts`. If using this, keep hosts.base up
 to date.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -10,20 +10,23 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   define_vagrant_vms config
   config.ssh.forward_agent = true
   config.ssh.insert_key = false
-  config.ssh.private_key_path = "~/.vagrant.d/insecure_private_key"
+  # Disable /vagrant folder syncing, it takes a lot of space on vm.
+  config.vm.synced_folder '.', '/vagrant',
+    disabled: true,
+    id: "vagrant-root"
   config.vm.box = "debian/wheezy64"
 
   config.vm.provision "ansible" do |ansible|
     ansible.playbook = "playbooks/site.yml"
     # ansible.verbose = 'vvvv'
     ansible.inventory_path = 'inventory.rb'
-    ansible.sudo = true
-    ansible.skip_tags = ['production_only']
+    ansible.become = true
+    ansible.skip_tags = ['production_only', 'fail2ban']
     ansible.host_key_checking = false
     ansible.raw_ssh_args = ['-o UserKnownHostsFile=/dev/null']
     ansible.force_remote_user = false
     ansible.extra_vars = {
       file_sync_no_controlhost: 'True',
-                         }
+    }
   end
 end

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,5 +1,4 @@
 [defaults]
-
 inventory = inventory.rb
 remote_user = root
 ansible_managed =  ansible managed - DO NOT MODIFY!
@@ -7,7 +6,8 @@ roles_path = ./dev_roles:playbooks/kifi_ansible_roles:./playbooks/kifi_ansible_u
 library = /opt/ansible-plugins/library
 filter_plugins = ./playbooks/filter_plugins
 timeout = 600
+# vault_password_file = <path to secret>
 
 [ssh_connection]
-
+pipelining = True
 ssh_args = -o ControlMaster=auto -o ControlPersist=60s -o ControlPath=/tmp/ansible-ssh-%h-%p-%r -o ForwardAgent=yes


### PR DESCRIPTION
- ansible sudo option is depricated, use become instead.
- Add ssh pipelining for faster playbook runs.
- Remove vagrant default /vagrant directory from vm,
as it takes a lot of space.
- Remove unnecessary ssh.private_key_path.
- Add to readme ansible installation instructions.