### PR TITLE
Add option vagrant_synced_folders.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ hosts.base
 playbooks
 shared
 .vagrant
+group_vars
+host_vars


### PR DESCRIPTION
* vagrant_synced_folders can be used in inventory.yml to add multiple
  shared folders to single host.
* inventory.rb tries to move old synced files to sites subdirectory,
  so that old vagrant machines will still work.
* Add symlinked folders to .gitignore.