### PR TITLE
Increase the default RAM to 1024 MB for libvirt

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -16,6 +16,10 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     id: "vagrant-root"
   config.vm.box = "debian/wheezy64"
 
+  config.vm.provider :libvirt do |libvirt|
+    libvirt.memory = 1024
+  end
+
   config.vm.provision "ansible" do |ansible|
     ansible.playbook = "playbooks/site.yml"
     # ansible.verbose = 'vvvv'


### PR DESCRIPTION
The default was 512 MB which was not enough for setting up one host.
The production machine had 1024 MB of memory, so increasing the amount
up to that should be safe.

It would be possible to specify the amount of memory host-by-host in
inventory.yaml but 1024 MB was decided to be a sufficient default amount
for other hosts as well.

Please note this change only affects the libvirt provider.